### PR TITLE
Fix 'error: you must provide one or more resources by argument or filename'

### DIFF
--- a/deploy.tf
+++ b/deploy.tf
@@ -261,9 +261,9 @@ resource "null_resource" "deploy_dns_addon" {
     depends_on = ["null_resource.setup_kubectl"]
     provisioner "local-exec" {
         command = <<EOF
-            sed -e "s/\$DNS_SERVICE_IP/10.3.0.10/" < 03-dns-addon.yaml > ./secrets/03-dns-addon.yaml.rendered
+            sed -e "s/\$DNS_SERVICE_IP/10.3.0.10/" < 03-dns-addon.yaml > ./secrets/03-dns-addon.rendered.yaml
             until kubectl get pods 2>/dev/null; do printf '.'; sleep 5; done
-            kubectl create -f ./secrets/03-dns-addon.yaml.rendered
+            kubectl create -f ./secrets/03-dns-addon.rendered.yaml
 EOF
     }
 }
@@ -272,13 +272,10 @@ resource "null_resource" "deploy_microbot" {
     depends_on = ["null_resource.setup_kubectl"]
     provisioner "local-exec" {
         command = <<EOF
-            sed -e "s/\$EXT_IP1/${digitalocean_droplet.k8s_worker.0.ipv4_address}/" < 04-microbot.yaml > ./secrets/04-microbot.yaml.rendered
+            sed -e "s/\$EXT_IP1/${digitalocean_droplet.k8s_worker.0.ipv4_address}/" < 04-microbot.yaml > ./secrets/04-microbot.rendered.yaml
             until kubectl get pods 2>/dev/null; do printf '.'; sleep 5; done
-            kubectl create -f ./secrets/04-microbot.yaml.rendered
+            kubectl create -f ./secrets/04-microbot.rendered.yaml
 
 EOF
     }
 }
-
-
-


### PR DESCRIPTION
I was getting this error:

```
Error applying plan:

2 error(s) occurred:

* Error running command '            sed -e "s/\$DNS_SERVICE_IP/10.3.0.10/" < 03-dns-addon.yaml > ./secrets/03-dns-addon.yaml.rendered
            until kubectl get pods 2>/dev/null; do printf '.'; sleep 5; done
            kubectl create -f ./secrets/03-dns-addon.yaml.rendered
': exit status 1. Output: NAME      READY     STATUS    RESTARTS   AGE
error: you must provide one or more resources by argument or filename

* Error running command '            sed -e "s/\$EXT_IP1/45.55.40.84/" < 04-microbot.yaml > ./secrets/04-microbot.yaml.rendered
            until kubectl get pods 2>/dev/null; do printf '.'; sleep 5; done
            kubectl create -f ./secrets/04-microbot.yaml.rendered

': exit status 1. Output: NAME      READY     STATUS    RESTARTS   AGE
error: you must provide one or more resources by argument or filename
```

Apparently kubectl wants the file to end in .yaml, otherwise it doesn't like it. This change fixes this error for me.
