### PR TITLE
Fixes #10, ssh fingerprint depends on ssh version

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ Then we setup the environment variables (step into `this repository` root). Note
 ```bash
 export TF_VAR_number_of_workers=3
 export TF_VAR_do_token=$(cat ./secrets/DO_TOKEN)
+export TF_VAR_ssh_fingerprint=$(ssh-keygen -E MD5 -lf ~/.ssh/id_rsa.pub | awk '{print $2}' | sed 's/MD5://g')
+```
+
+If you are using an older version of OpenSSH (<6.9), replace the last line with
+```bash
 export TF_VAR_ssh_fingerprint=$(ssh-keygen -lf ~/.ssh/id_rsa.pub | awk '{print $2}')
 ```
 

--- a/setup_terraform.sh
+++ b/setup_terraform.sh
@@ -2,7 +2,7 @@
 # Usage:
 #	. ./setup_terraform.sh
 
-export TF_VAR_number_of_workers=1
+export TF_VAR_number_of_workers=3
 export TF_VAR_do_token=$(cat ./secrets/DO_TOKEN)
 
 # ssh -V prints to stderr, redirect

--- a/setup_terraform.sh
+++ b/setup_terraform.sh
@@ -2,6 +2,16 @@
 # Usage:
 #	. ./setup_terraform.sh
 
-export TF_VAR_number_of_workers=3
+export TF_VAR_number_of_workers=1
 export TF_VAR_do_token=$(cat ./secrets/DO_TOKEN)
-export TF_VAR_ssh_fingerprint=$(ssh-keygen -lf ~/.ssh/id_rsa.pub | awk '{print $2}')
+
+# ssh -V prints to stderr, redirect
+ssh_ver=$(ssh -V 2>&1)
+[[ $ssh_ver =~ OpenSSH_([0-9][.][0-9]) ]] && version="${BASH_REMATCH[1]}"
+# if ssh version is under 6.9, use -lf, otherwise must use the -E version
+if ! awk -v ver="$version" 'BEGIN { if (ver < 6.9) exit 1; }'; then
+    export TF_VAR_ssh_fingerprint=$(ssh-keygen -lf ~/.ssh/id_rsa.pub | awk '{print $2}')
+else
+    export TF_VAR_ssh_fingerprint=$(ssh-keygen -E MD5 -lf ~/.ssh/id_rsa.pub | awk '{print $2}' | sed 's/MD5://g')
+fi
+


### PR DESCRIPTION
I'm not 100% sure that the -E option was added in
6.9, but in OpenSSH release notes[1], first mention
of -E is at 6.9.

Thanks to jordanm on stackoverflow[2] for insight
on how to switch based on version.

[1] http://www.openssh.com/releasenotes.html
[2] http://stackoverflow.com/a/11602790
