### PR TITLE
Adds LICENSE and AUTHORS files

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,10 @@
+## Contributors
+
+Created by [Herman Junge](https://github.com/hermanjunge)
+
+With contributions from:
+
+- [Stefan Codrescu](https://github.com/5tefan)
+- [Marcos](https://github.com/arkanus)
+- [Patrick O'Connor](https://github.com/dontrebootme)
+- [Dario Nieuwenhuis](https://github.com/Dirbaio)

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Herman Junge
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Re. #12 adding MIT license [1] and AUTHORS.md file.
Contributions taken from listing at [2].

[1] http://choosealicense.com/licenses/mit/#
[2] https://github.com/hermanjunge/kubernetes-digitalocean-terraform/graphs/contributors
