### PR TITLE
Private Network Interfaces

### DIFF
--- a/00-etcd.yaml
+++ b/00-etcd.yaml
@@ -2,7 +2,7 @@
 
 coreos:
   etcd2:
-    advertise-client-urls: https://$public_ipv4:2379
+    advertise-client-urls: https://$private_ipv4:2379 # multi-region and multi-cloud deployments need to use $public_ipv4
     listen-client-urls: https://0.0.0.0:2379
     client-cert-auth: true
     trusted-ca-file: /etc/kubernetes/ssl/ca.pem

--- a/01-master.yaml
+++ b/01-master.yaml
@@ -4,7 +4,7 @@ write_files:
   - path: "/etc/flannel/options.env"
     permissions: "0755"
     content: |
-        FLANNELD_IFACE=$public_ipv4
+        FLANNELD_IFACE=$private_ipv4
         FLANNELD_ETCD_ENDPOINTS=https://${ETCD_IP}:2379
         FLANNELD_ETCD_CAFILE=/etc/ssl/etcd/ca.pem
         FLANNELD_ETCD_CERTFILE=/etc/ssl/etcd/client.pem
@@ -39,7 +39,7 @@ write_files:
           --register-schedulable=false \
           --allow-privileged=true \
           --config=/etc/kubernetes/manifests \
-          --hostname-override=$public_ipv4 \
+          --hostname-override=$private_ipv4 \
           --cluster-dns=${DNS_SERVICE_IP} \
           --cluster-domain=cluster.local
         Restart=always
@@ -70,7 +70,7 @@ write_files:
             - --allow-privileged=true
             - --service-cluster-ip-range=${SERVICE_IP_RANGE}
             - --secure-port=443
-            - --advertise-address=$public_ipv4
+            - --advertise-address=$private_ipv4
             - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota
             - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
             - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem

--- a/02-worker.yaml
+++ b/02-worker.yaml
@@ -5,7 +5,7 @@ write_files:
   - path: "/etc/flannel/options.env"
     permissions: "0755"
     content: |
-        FLANNELD_IFACE=$public_ipv4
+        FLANNELD_IFACE=$private_ipv4
         FLANNELD_ETCD_ENDPOINTS=https://${ETCD_IP}:2379
         FLANNELD_ETCD_CAFILE=/etc/ssl/etcd/ca.pem
         FLANNELD_ETCD_CERTFILE=/etc/ssl/etcd/worker.pem
@@ -40,7 +40,7 @@ write_files:
           --register-node=true \
           --allow-privileged=true \
           --config=/etc/kubernetes/manifests \
-          --hostname-override=$public_ipv4 \
+          --hostname-override=$private_ipv4 \
           --cluster-dns=${DNS_SERVICE_IP} \
           --cluster-domain=cluster.local \
           --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \

--- a/deploy.tf
+++ b/deploy.tf
@@ -152,7 +152,7 @@ resource "digitalocean_droplet" "k8s_master" {
     # Generate k8s_master server certificate
     provisioner "local-exec" {
         command = <<EOF
-            $PWD/cfssl/generate_server.sh k8s_master "${digitalocean_droplet.k8s_master.ipv4_address},10.3.0.1,kubernetes.default,kubernetes"
+            $PWD/cfssl/generate_server.sh k8s_master "${digitalocean_droplet.k8s_master.ipv4_address},${digitalocean_droplet.k8s_master.ipv4_address_private},10.3.0.1,kubernetes.default,kubernetes"
 EOF
     }
 
@@ -247,7 +247,7 @@ data "template_file" "worker_yaml" {
     vars {
         DNS_SERVICE_IP = "10.3.0.10"
         ETCD_IP = "${digitalocean_droplet.k8s_etcd.ipv4_address_private}"
-        MASTER_HOST = "${digitalocean_droplet.k8s_master.ipv4_address}"
+        MASTER_HOST = "${digitalocean_droplet.k8s_master.ipv4_address_private}"
         HYPERCUBE_VERSION = "${var.hypercube_version}"
     }
 }


### PR DESCRIPTION
Use digital ocean internal network for etcd + cluster communication.
- master needs to be available via public net as well for `kubectl`

See:
https://www.digitalocean.com/company/blog/introducing-private-networking/