### PR TITLE
upgrade to kubernetes v1.7

### DIFF
--- a/01-master.yaml
+++ b/01-master.yaml
@@ -77,6 +77,7 @@ write_files:
             - --allow-privileged=true
             - --service-cluster-ip-range=${SERVICE_IP_RANGE}
             - --secure-port=443
+            - --storage-backend=etcd2
             - --advertise-address=$private_ipv4
             - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota
             - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem

--- a/01-master.yaml
+++ b/01-master.yaml
@@ -84,7 +84,6 @@ write_files:
             - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
             - --client-ca-file=/etc/kubernetes/ssl/ca.pem
             - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem
-            - --runtime-config=extensions/v1beta1/networkpolicies=true
             - --anonymous-auth=false
             livenessProbe:
               httpGet:

--- a/deploy.tf
+++ b/deploy.tf
@@ -35,7 +35,7 @@ variable "size_etcd" {
 }
 
 variable "size_master" {
-    default = "512mb"
+    default = "1gb"
 }
 
 variable "size_worker" {

--- a/deploy.tf
+++ b/deploy.tf
@@ -23,7 +23,7 @@ variable "ssh_private_key" {
 
 variable "number_of_workers" {}
 variable "hyperkube_version" {
-    default = "v1.5.4_coreos.0"
+    default = "v1.7.3_coreos.0"
 }
 
 variable "prefix" {


### PR DESCRIPTION
Working off of https://github.com/kubernetes-digitalocean-terraform/kubernetes-digitalocean-terraform/pull/39. This is a seperate PR to only upgrade to kubernetes v1.7 

On a side note I'd like to increase the default size of the masters, I find that only having 1 core usually overloads the servers.