### PR TITLE
Add firewalls to nodes

### DIFF
--- a/deploy.tf
+++ b/deploy.tf
@@ -374,8 +374,10 @@ EOF
 
 ###############################################################################
 #
-# etcd host firewall
+# etcd host inbound firewall rules
 #
+# TCP port 22 from master node for debugging over ssh
+# TCP ports 2379-2380 from master and worker nodes for etcd server client API
 ###############################################################################
 
 resource "digitalocean_firewall" "k8s_etcd" {
@@ -413,8 +415,14 @@ resource "digitalocean_firewall" "k8s_etcd" {
 
 ###############################################################################
 #
-# worker host firewall
+# worker host inbound firewall rules
 #
+# TCP port 22 from master node for debugging over ssh
+# TCP port 10250 from Master nodes for Kubelet API exec and logs.
+# TCP port 10255 from Heapster Worker node for read-only Kubelet API.
+# TCP port ALL from Master & Worker Nodes for Intra-cluster communication (unnecessary if vxlan is used for networking)
+# UDP port 8285 from Master & Worker Nodes for flannel overlay network - udp backend. This is the default network configuration
+# UDP port 8472 from Master & Worker Nodes 	flannel overlay network - vxlan backend (only required if using flannel)
 ###############################################################################
 
 resource "digitalocean_firewall" "k8s_worker" {
@@ -471,8 +479,12 @@ resource "digitalocean_firewall" "k8s_worker" {
 
 ###############################################################################
 #
-# master host firewall
+# master host inbound firewallrules
 #
+# TCP port 22 for debugging over ssh
+# TCP port 443 for accessing Kubernetes API server.
+# UDP port 8285 from Worker Nodes for flannel overlay network - udp backend.
+# UDP port 8472 from Worker Nodes for lannel overlay network - vxlan backend
 ###############################################################################
 
 resource "digitalocean_firewall" "k8s_master" {

--- a/deploy.tf
+++ b/deploy.tf
@@ -461,6 +461,11 @@ resource "digitalocean_firewall" "k8s_worker" {
       port_range         = "80"
       source_addresses = ["0.0.0.0/0"]
     },
+    {
+      protocol           = "tcp"
+      port_range         = "443"
+      source_addresses = ["0.0.0.0/0"]
+    },
   ]
 
   outbound_rule = [


### PR DESCRIPTION
Please consider this pull request to setup firewall. The firewalls are configured following these indications:
https://coreos.com/kubernetes/docs/latest/kubernetes-networking.html

we also:

  * allow port 80 on workers
  * allow port 22 on master
  * force internal communication over private network

Please note, port 22 is only available on master node. If you need to
ssh to workers or etcd nodes you can either open that port or preferably
configure ssh to proxy through master with something similar to the
following:

Host k8s-master
  HostName $PUBLIC_IP_OF_MASTER_NODE
  User core
  IdentityFile ~/.ssh/rsa_id

Host k8s-etcd
  HostName $PRIVATE_IP_OF_ETCD_NODE
  User core
  ProxyJump core@master:22
  IdentityFile ~/.ssh/rsa_id